### PR TITLE
Added rtree to list of dependencies and created requirements.txt

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,9 +28,9 @@ Features
 
 Installation
 ============
-RBF requires the following python packages: numpy, scipy, sympy, and
-cython.  These dependencies should be satisfied with just the base
-Anaconda python package (https://www.continuum.io/downloads)
+RBF requires the following python packages: numpy, scipy, sympy,
+cython, and rtree. These dependencies should be satisfied with just
+the base Anaconda python package (https://www.continuum.io/downloads)
 
 download the RBF package
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+numpy
+scipy
+sympy
+cython
+rtree


### PR DESCRIPTION
While performing the unit tests, I got 

> ModuleNotFoundError: No module named 'rtree'

So I am updating the list of dependencies.