### PR TITLE
Re-enable higher-dimensional RBFs

### DIFF
--- a/rbf/basis.py
+++ b/rbf/basis.py
@@ -63,7 +63,6 @@ from scipy.spatial import cKDTree
 from sympy.utilities.autowrap import ufuncify
 from sympy import lambdify
 
-
 from rbf.utils import assert_shape
 
 
@@ -333,7 +332,6 @@ class RBF(object):
             out = func(*x, *c, eps, out=out)
         else:
             out[...] = func(*x, *c, eps)
-
         return out
 
     def center_value(self, eps=1.0, diff=(0,)):

--- a/test/test_basis.py
+++ b/test/test_basis.py
@@ -212,4 +212,20 @@ class Test(unittest.TestCase):
     rbf.basis.phs2(x, y, out=out5)
     self.assertTrue(np.allclose(out1, out5))
 
+    # test dimensions > 15
+    x = np.random.random((5, 16))
+    y = np.random.random((4, 16))
+    out6 = rbf.basis.phs2(x, y)
+
+    out7 = np.empty((5, 4))
+    self.assertRaises(rbf.basis.InplaceError, rbf.basis.phs2, x, y, out=out7)
+
+    out8 = np.empty((5, 4))
+    rbf.basis.phs2(x, y, out=out8, out_compat=True)
+    self.assertTrue(np.allclose(out6, out8))
+
+    out9 = np.empty((4, 5)).T
+    rbf.basis.phs2(x, y, out=out9, out_compat=True)
+    self.assertTrue(np.allclose(out6, out9))
+
 #unittest.main()

--- a/test/test_basis.py
+++ b/test/test_basis.py
@@ -218,14 +218,11 @@ class Test(unittest.TestCase):
     out6 = rbf.basis.phs2(x, y)
 
     out7 = np.empty((5, 4))
-    self.assertRaises(rbf.basis.InplaceError, rbf.basis.phs2, x, y, out=out7)
+    rbf.basis.phs2(x, y, out=out7)
+    self.assertTrue(np.allclose(out6, out7))
 
-    out8 = np.empty((5, 4))
-    rbf.basis.phs2(x, y, out=out8, out_compat=True)
+    out8 = np.empty((4, 5)).T
+    rbf.basis.phs2(x, y, out=out8)
     self.assertTrue(np.allclose(out6, out8))
-
-    out9 = np.empty((4, 5)).T
-    rbf.basis.phs2(x, y, out=out9, out_compat=True)
-    self.assertTrue(np.allclose(out6, out9))
 
 #unittest.main()


### PR DESCRIPTION
Closes #35.
Adds logic to automatically switch to `lambdify` when number of dimensions exceeds the number that `ufuncify` can handle, as well as accompanying documentation and test cases.